### PR TITLE
Add product creation, location tracking with immutable history, and secure role revocation to support full supply chain lifecycle

### DIFF
--- a/contracts/STX-OriginTrailr.clar
+++ b/contracts/STX-OriginTrailr.clar
@@ -124,3 +124,97 @@
   )
 )
 
+
+
+(define-public (revoke-role (address principal))
+  (let ((current-role (safe-get-role address)))
+    (begin
+      (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+      (asserts! (get is-active current-role) ERR-NOT-FOUND)
+      (ok (map-set roles address { 
+        role: u"", 
+        is-active: false 
+      }))
+    )
+  )
+)
+
+(define-private (safe-get-product (product-id uint))
+  (map-get? products product-id)
+)
+
+(define-public (add-product 
+    (name (string-utf8 100)) 
+    (origin (string-utf8 50)) 
+    (location (string-utf8 100)))
+  (let 
+    (
+      (safe-id (var-get product-counter))
+      (existing-product (safe-get-product safe-id))
+      (validated-strings (validate-strings name origin location))
+    )
+    (begin
+      (asserts! (check-role tx-sender MANUFACTURER) ERR-NOT-AUTHORIZED)
+      (asserts! validated-strings ERR-INVALID-INPUT)
+      (asserts! (is-none existing-product) ERR-ALREADY-EXISTS)
+      (map-set products safe-id
+        {
+          id: safe-id,
+          name: name,
+          manufacturer: tx-sender,
+          origin: origin,
+          timestamp: stacks-block-height,
+          current-location: location,
+          status: u"created"
+        })
+      (var-set product-counter (+ safe-id u1))
+      (ok safe-id)
+    )
+  )
+)
+
+;; Update location and add history entry
+(define-public (update-location 
+    (product-id uint) 
+    (new-location (string-utf8 100)))
+  (let (
+      (product (safe-get-product product-id))
+      (valid-location (is-valid-string-length new-location MAX-STRING-LENGTH-100))
+      (change-id (var-get change-counter))
+    )
+    (begin
+      (asserts! (or 
+        (check-role tx-sender TRANSPORTER)
+        (check-role tx-sender MANUFACTURER)) ERR-NOT-AUTHORIZED)
+      (asserts! valid-location ERR-INVALID-INPUT)
+      (asserts! (is-some product) ERR-NOT-FOUND)
+      ;; Update the product with the new location
+      (map-set products product-id
+        (merge (unwrap! product ERR-NOT-FOUND)
+          { current-location: new-location }))
+      ;; Add a new entry to the product history
+      (map-set product-history {product-id: product-id, change-id: change-id}
+        {
+          timestamp: stacks-block-height,
+          location: new-location,
+          status: (get status (unwrap! product ERR-NOT-FOUND))
+        })
+      ;; Increment the change counter
+      (var-set change-counter (+ change-id u1))
+      (ok change-id)
+    )
+  )
+)
+
+;; New function to get the product's history
+(define-read-only (get-product-history (product-id uint))
+  (map-get? product-history {product-id: product-id, change-id: u0})
+)
+
+(define-read-only (get-product (product-id uint))
+  (safe-get-product product-id)
+)
+
+(define-read-only (get-role (address principal))
+  (safe-get-role address)
+)


### PR DESCRIPTION

##  Pull Request: Product Lifecycle, Role Revocation & History Tracking

### Summary

This PR builds upon the role management foundation by introducing complete product lifecycle features, including product creation, location updates with immutable change history, and secure role revocation. These additions significantly advance the contract toward a fully functional supply chain tracking system on Stacks.

---

### 🚫 Role Revocation

#### `revoke-role (address)`

* Allows the contract owner to deactivate a role for a given user.
* Sets the user's role to an empty string and marks them as inactive.
* Prevents previously authorized users from interacting with restricted functions.

✅ **Checks**:

* Only the contract owner can revoke roles.
* Role must be active to be revoked.

---

### 📦 Product Management

#### `add-product (name, origin, location)`

Registers a new product with key metadata.

* **Role Required**: `MANUFACTURER`
* Automatically assigns a unique product ID using `product-counter`.
* Ensures string inputs are valid and non-empty.
* Rejects duplicate product IDs.

🏷️ Product fields include:

* ID, Name, Manufacturer address, Origin, Timestamp, Current location, and Status (`"created"`)

---

### 🚚 Location & History Tracking

#### `update-location (product-id, new-location)`

Updates the product’s current location and logs a historical entry.

* **Roles Allowed**: `MANUFACTURER` or `TRANSPORTER`
* Adds a new entry in the `product-history` map using `change-counter`.
* Preserves existing status and timestamps each update with the current block height.

✅ Ensures:

* Product exists before updating
* Location string is valid
* History is immutable and uniquely indexed

---

### 🔍 Read-Only Views

#### `get-product-history (product-id)`

Returns the **first** history record for the given product (i.e. `change-id: 0`).
🧠 **Note**: You may want to iterate this in future versions to return full history lists.

#### `get-product (product-id)`

Returns product details (or `none` if not found).

#### `get-role (address)`

Returns the user's current role and active status.

---

### 🛠 Internal Enhancements

* `safe-get-product`: Utility to safely fetch product data from the `products` map.
* Reuses `is-valid-string-length` and `validate-strings` for consistent input validation.

---

